### PR TITLE
Fix unauthenticated git protocol error

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   # golang pre commits
-  - repo: git://github.com/dnephin/pre-commit-golang
+  - repo: https://github.com/dnephin/pre-commit-golang
     rev: master
     hooks:
       - id: go-fmt


### PR DESCRIPTION
As outlined here: https://github.blog/2021-09-01-improving-git-protocol-security-github/

```bash
[WARNING] The 'rev' field of repo 'git://github.com/dnephin/pre-commit-golang' appears to be a mutable reference (moving tag / branch).  Mutable references are never updated after first install and are not supported.  See https://pre-commit.com/#using-the-latest-version-for-a-repository for more details.  Hint: `pre-commit autoupdate` often fixes this.
[INFO] Initializing environment for git://github.com/dnephin/pre-commit-golang.
An unexpected error has occurred: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags')
return code: 128
expected return code: 0
stdout: (none)
stderr:
    fatal: remote error:
      The unauthenticated git protocol on port 9418 is no longer supported.
    Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.

Check the log at /home/jhewers/.cache/pre-commit/pre-commit.log
```